### PR TITLE
fix: use correct SDK method in setNormalMode function

### DIFF
--- a/src/main/java/cl/transbank/possdk/example/PrimaryController.java
+++ b/src/main/java/cl/transbank/possdk/example/PrimaryController.java
@@ -386,7 +386,7 @@ public class PrimaryController implements Initializable {
     private void onSetNormalMode() {
         print("+ set normal mode");
         try {
-            boolean result = App.getPos().poll();
+            boolean result = App.getPos().setNormalMode();
             String resultText = String.format("normal mode: %s", result ? "Ok" : "NOk");
             print(resultText);
             txtAreaRegister.setText(resultText);


### PR DESCRIPTION
Fixed the setNormalMode function, now using the correct method from the SDK.

Test
<img width="1129" alt="image" src="https://github.com/TransbankDevelopers/transbank-pos-sdk-java-example/assets/36648048/05ab6b37-05a9-4374-9772-2779ecf5c36e">
